### PR TITLE
feat: alphabetically sort list key values

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This package enforces consistent formatting of pyproject.toml files, reducing me
 - Alphabetically sorts pyproject.toml by:
   - section
   - section key
+  - list value
 - Reformats pyproject.toml to a standardised style
 
 ## Installation
@@ -32,6 +33,13 @@ pip install pyprojectsort
 With the following `pyproject.toml` contained inside a directory:
 
 ```toml
+[tool.ruff]
+ignore = [
+    "G004",
+"T201",
+    "ANN",
+]
+
 [project]
 name = "pyprojectsort"
 
@@ -67,6 +75,13 @@ exclude = "tests/*,venv/*"
 show_complexity = true
 show_mi = true
 total_average = true
+
+[tool.ruff]
+ignore = [
+    "ANN",
+    "G004",
+    "T201",
+]
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ convention = "google"
 [tool.mypy]
 mypy_path = "pyprojectsort"
 files = "."
-exclude = "__init__.py|setup.py|docs|tests|venv"
+exclude = "__init__.py|docs|tests|venv"
 
 [tool.pylint]
 recursive = true

--- a/pyprojectsort/main.py
+++ b/pyprojectsort/main.py
@@ -22,7 +22,7 @@ def reformat_pyproject(pyproject: dict) -> dict:
             for key, value in sorted(pyproject.items(), key=lambda item: item[0])
         }
     if isinstance(pyproject, list):
-        return [reformat_pyproject(item) for item in pyproject]
+        return sorted(reformat_pyproject(item) for item in pyproject)
     return pyproject
 
 


### PR DESCRIPTION
Alphabetically sorts `pyproject.toml` list values.

Reformats:

```toml
[tool.ruff]
ignore = [
    "T201",
    "ANN",
]
```

to:

```toml
[tool.ruff]
ignore = [
    "ANN",
    "T201",
]
```