### PR TITLE
feat: specify pyproject path from cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,6 @@ exclude_dirs = [
     "venv",
 ]
 
-[tool.black]
-preview = true
-
 [tool.coverage.html]
 directory = "docs/coverage"
 

--- a/pyprojectsort/main.py
+++ b/pyprojectsort/main.py
@@ -1,17 +1,48 @@
 """pyprojectsort implementation."""
 from __future__ import annotations
 
+import argparse
 import pathlib
+import sys
+from typing import Any
 
 import tomli as tomllib
 import tomli_w
 
-with pathlib.Path("pyproject.toml").open("rb") as f:
-    pyproject_toml = tomllib.load(f)
-toml_config = pyproject_toml.get("project")
-project_metadata = {
-    k.replace("--", "").replace("-", "_"): v for k, v in toml_config.items()
-}
+from pyprojectsort import __version__
+
+DEFAULT_CONFIG = "pyproject.toml"
+
+
+def _read_cli(args: list):
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        prog="pyprojectsort",
+        description="Formatter for pyproject.toml files",
+    )
+    parser.add_argument("file", nargs="?", default=DEFAULT_CONFIG)
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=__version__,
+        help="show package version and exit",
+    )
+    return parser.parse_args(args)
+
+
+def _read_config_file(config: pathlib.Path):
+    """Check configuration file exists."""
+    if not config.is_file():
+        print(f"No pyproject.toml detected at path: '{config}'")
+        sys.exit(1)
+    return config
+
+
+def _parse_pyproject_toml(file: pathlib.Path) -> dict[str, Any]:
+    """Parse pyproject.toml file."""
+    with file.open("rb") as f:
+        pyproject_toml = tomllib.load(f)
+    return {k.replace("--", "").replace("-", "_"): v for k, v in pyproject_toml.items()}
 
 
 def reformat_pyproject(pyproject: dict) -> dict:
@@ -26,8 +57,16 @@ def reformat_pyproject(pyproject: dict) -> dict:
     return pyproject
 
 
+def _save_pyproject(file, pyproject) -> None:
+    """Write changes to pyproject.toml."""
+    with file.open("wb") as f:
+        tomli_w.dump(pyproject, f)
+
+
 def main():
     """Run application."""
-    data_dict = reformat_pyproject(pyproject_toml)
-    with pathlib.Path("pyproject.toml").open("wb") as f:
-        tomli_w.dump(data_dict, f)
+    args = _read_cli(sys.argv[1:])
+    pyproject_file = _read_config_file(pathlib.Path(args.file))
+    pyproject_toml = _parse_pyproject_toml(pyproject_file)
+    reformatted_pyproject = reformat_pyproject(pyproject_toml)
+    _save_pyproject(pyproject_file, reformatted_pyproject)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,7 +2,39 @@
 
 from __future__ import annotations
 
-from pyprojectsort.main import reformat_pyproject
+import pathlib
+import unittest.mock
+
+import pytest
+
+from pyprojectsort.main import _read_cli, _read_config_file, main, reformat_pyproject
+
+
+def test_default_filename():
+    """Check expected default pyproject filename."""
+    assert _read_cli([]).file == "pyproject.toml"
+
+
+def test_version():
+    """Check expected default pyproject filename."""
+    with pytest.raises(SystemExit) as version:
+        _read_cli(["--version"])
+    assert version.value.code == 0
+
+
+def test_invalid_config_file_path():
+    """SystemExit raised if config file path does not exist."""
+    with pytest.raises(SystemExit) as invalid_config:
+        _read_config_file(pathlib.Path("test_data.toml"))
+    assert invalid_config.value.code == 1
+
+
+@unittest.mock.patch("pathlib.Path.is_file")
+def test_valid_config_file_path(is_file):
+    """Test a valid file path is provided."""
+    is_file.return_value = True
+    file_path = pathlib.Path("test_data.toml")
+    assert _read_config_file(file_path) == file_path
 
 
 def test_reformat_pyproject():
@@ -22,3 +54,29 @@ def test_reformat_pyproject():
         "tool.pylint": {"ignore": ["docs", "tests", "venv"]},
     }
     assert reformat_pyproject(pyproject) == sorted_pyproject
+
+
+class TestArgs:
+    """Test class for command line arguments."""
+
+    file = "test_data.toml"
+
+
+@unittest.mock.patch("pyprojectsort.main._save_pyproject")
+@unittest.mock.patch("pyprojectsort.main.reformat_pyproject")
+@unittest.mock.patch("pyprojectsort.main._parse_pyproject_toml")
+@unittest.mock.patch("pyprojectsort.main._read_config_file")
+@unittest.mock.patch("pyprojectsort.main._read_cli")
+def test_main(
+    read_cli,
+    read_config,
+    parse_pyproject,
+    reformat_pyproject,
+    save_pyproject,
+):
+    """Test main application function."""
+    read_cli.return_value = TestArgs()
+    read_config.return_value = pathlib.Path()
+    parse_pyproject.return_value = {}
+    reformat_pyproject.return_value = {}
+    main()


### PR DESCRIPTION
Enables pyproject.toml file path to be specified from the command line e.g. `pyprojectsort ../pyproject.toml`.

Provides a `--version` command line option to check the package version.