### PR TITLE
fix: build error due to absolute import

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This package enforces consistent formatting of pyproject.toml files, reducing me
   - section key
   - list value
 - Reformats pyproject.toml to a standardised style
+  - Double quotations
+  - Trailing commas
+  - Line per value for list length above three
+    - or less with explicit trailing commas
 
 ## Installation
 
@@ -37,11 +41,11 @@ With the following `pyproject.toml` contained inside a directory:
 ignore = [
     "G004",
 "T201",
-    "ANN",
+    "ANN"
 ]
 
 [project]
-name = "pyprojectsort"
+name = 'pyprojectsort'
 
 [tool.radon]
 show_mi = true

--- a/pyprojectsort/__main__.py
+++ b/pyprojectsort/__main__.py
@@ -1,0 +1,7 @@
+"""Entry point to run pyprojectsort."""
+from __future__ import annotations
+
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/pyprojectsort/__version__.py
+++ b/pyprojectsort/__version__.py
@@ -5,7 +5,7 @@ This package uses Semantic Versioning, see: https://semver.org.
 from __future__ import annotations
 
 MAJOR = 0
-MINOR = 1
-MICRO = 1
+MINOR = 2
+MICRO = 0
 
 __version__ = f"{MAJOR}.{MINOR}.{MICRO}"

--- a/pyprojectsort/main.py
+++ b/pyprojectsort/main.py
@@ -9,7 +9,7 @@ from typing import Any
 import tomli as tomllib
 import tomli_w
 
-from pyprojectsort import __version__
+from . import __version__
 
 DEFAULT_CONFIG = "pyproject.toml"
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 --requirement requirements.txt
-coverage==7.2.7
 packaging==23.1
 pytest==7.4.0
 pytest-cov==4.1.0

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -87,7 +87,7 @@ def test_reformat_pyproject():
     assert reformat_pyproject(pyproject) == sorted_pyproject
 
 
-class TestArgs:
+class CLIArgs:
     """Test class for command line arguments."""
 
     def __init__(
@@ -113,7 +113,7 @@ def test_main_with_file_reformatted(
     save_pyproject,
 ):
     """Test file reformatted."""
-    args = TestArgs()
+    args = CLIArgs()
     read_cli.return_value = args
     read_config.return_value = pathlib.Path()
     parse_pyproject.return_value = {}
@@ -139,7 +139,7 @@ def test_main_with_file_unchanged(
     save_pyproject,
 ):
     """Test file left unchanged."""
-    args = TestArgs()
+    args = CLIArgs()
     read_cli.return_value = args
     read_config.return_value = pathlib.Path()
     parse_pyproject.return_value = {}
@@ -162,7 +162,7 @@ def test_check_option_reformat_needed(
     reformat_pyproject,
 ):
     """Test --check option when reformat occurs."""
-    args = TestArgs(check=True)
+    args = CLIArgs(check=True)
     read_cli.return_value = args
     read_config.return_value = pathlib.Path()
     parse_pyproject.return_value = {}
@@ -186,7 +186,7 @@ def test_check_option_reformat_not_needed(
     reformat_pyproject,
 ):
     """Test --check option when reformat is not needed."""
-    args = TestArgs(check=True)
+    args = CLIArgs(check=True)
     read_cli.return_value = args
     read_config.return_value = pathlib.Path()
     parse_pyproject.return_value = {"unchanged": 1}


### PR DESCRIPTION
- renamed TestArgs class to CLIArgs in unit tests to avoid attempted test discovery
- bumped package version to 0.2.0
- removed redundant 'coverage' dependency that is installed via 'pytest-cov'