### PR TITLE
Official support for Python 3.7-3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,19 +40,19 @@ jobs:
         run: perflint .
 
   run-tests:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
-        python-version: ["3.10"]
-        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
     name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/checkout@v2
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![image](https://badge.fury.io/py/pyprojectsort.svg)](https://pypi.org/project/pyprojectsort/)
 ![image](https://img.shields.io/badge/license-MIT-blue)
-[![image](https://img.shields.io/pypi/pyversions/pyprojectsort.svg)](https://pypi.python.org/pypi/pyprojectsort)
+[![image](https://img.shields.io/pypi/pyversions/pyprojectsort.svg)](https://pypi.org/pypi/pyprojectsort)
 ![Supported platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-green)
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
     "tomli-w==1.0.0",


### PR DESCRIPTION
Tests the package against Python 3.7 to Python 3.11 on MacOS, Windows and Linux in its GitHub workflow.