### PR TITLE
Natural sort string-based numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # pyprojectsort
 
-[![image](https://badge.fury.io/py/pyprojectsort.svg)](https://pypi.org/project/pyprojectsort/)
-![image](https://img.shields.io/badge/license-MIT-blue)
-[![image](https://img.shields.io/pypi/pyversions/pyprojectsort.svg)](https://pypi.org/pypi/pyprojectsort)
+[![PyPI Version](https://badge.fury.io/py/pyprojectsort.svg)](https://pypi.org/project/pyprojectsort/)
+![LICENSE](https://img.shields.io/badge/license-MIT-blue)
+[![Python versions](https://img.shields.io/pypi/pyversions/pyprojectsort.svg)](https://pypi.org/pypi/pyprojectsort)
 ![Supported platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-green)
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
@@ -15,7 +15,7 @@ This package enforces consistent formatting of pyproject.toml files, reducing me
 
 ## Features
 
-- Alphabetically sorts pyproject.toml by:
+- Alphanumerically sorts pyproject.toml by:
   - section
   - section key
   - list value

--- a/cspell.json
+++ b/cspell.json
@@ -24,6 +24,8 @@
         "maxdepth",
         "mdinclude",
         "modindex",
+        "natsort",
+        "natsorted",
         "peaceiris",
         "perflint",
         "popd",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
+    "natsort==8.4.0",
     "tomli-w==1.0.0",
     "tomli==2.0.1",
 ]

--- a/pyprojectsort/main.py
+++ b/pyprojectsort/main.py
@@ -7,6 +7,7 @@ import sys
 from difflib import unified_diff
 from typing import Any
 
+import natsort
 import tomli as tomllib
 import tomli_w
 
@@ -120,7 +121,8 @@ def reformat_pyproject(pyproject: dict | list) -> dict:
     """Reformat pyproject toml file."""
     if isinstance(pyproject, dict):
         return {
-            key: reformat_pyproject(value) for key, value in sorted(pyproject.items())
+            key: reformat_pyproject(value)
+            for key, value in natsort.natsorted(pyproject.items())
         }
     if isinstance(pyproject, list):
         data_types = {bool: [], float: [], int: [], str: [], list: [], dict: []}
@@ -135,8 +137,8 @@ def reformat_pyproject(pyproject: dict | list) -> dict:
 
         return (
             data_types[bool]
-            + sorted(data_types[int] + data_types[float], key=str)
-            + sorted(data_types[str])
+            + sorted(data_types[int] + data_types[float], key=float)
+            + natsort.natsorted(data_types[str])
             + _bubble_sort(data_types[list])
             + _bubble_sort(data_types[dict])
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+natsort==8.4.0
 tomli==2.0.1
 tomli-w==1.0.0


### PR DESCRIPTION
Naturally sorts string-based numbers to prevent sorting on a digit-by-digit basis e.g. sorting "11" ahead of "7" due to comparing "1" against "7" as opposed to the full number.