### PR TITLE
fix: Bump pyprojectsort pre-commit to v0.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/kieran-ryan/pyprojectsort
-    rev: v0.3.0
+    rev: v0.4.0
     hooks:
       - id: pyprojectsort
   - repo: https://github.com/asmeurer/removestar


### PR DESCRIPTION
### 🤔 What's changed?

- Bump `pyprojectsort` pre-commit version to `v0.4.0`

### ⚡️ What's your motivation? 

- Contains fix #75 to enable pre-commit pipeline runs

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

NA
