### PR TITLE
Use official codecov action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,16 +23,10 @@ jobs:
         run: uv run pytest
 
       - name: Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           files: .reports/coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          files: .reports/junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build-docs:


### PR DESCRIPTION
### 🤔 What's changed?

- Migrated to the multipurpose codecov GitHub action rather than the test results endpoint

### ⚡️ What's your motivation?

- Frequently updated reusable action
- Speed and security

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)